### PR TITLE
PRA-77 Нет catch в промисах

### DIFF
--- a/packages/client/src/pages/Game/Game.tsx
+++ b/packages/client/src/pages/Game/Game.tsx
@@ -50,7 +50,7 @@ export const Game: React.FC = () => {
       const send = async (res: AddLeader) => {
         try {
           const result = await addToLeaderBoard(res);
-          const resp = await result.json();
+          const resp = await result?.json();
           if (resp.ok) {
             setShowError(false);
           } else {
@@ -58,6 +58,8 @@ export const Game: React.FC = () => {
             setErrorMsg(`Что-то пошло не так :( сервер говорит ${JSON.stringify(resp)}`);
           }
         } catch (error) {
+          setShowError(true);
+          setErrorMsg(`Ошибка: ${(error as Error)?.message}. Переходим на страницу авторизации`);
           return;
         }
       };
@@ -108,8 +110,9 @@ export const Game: React.FC = () => {
   }, [navigate]);
 
   const handleErrorMsg = useCallback(() => {
+    navigate('/login');
     setShowError(false);
-  }, []);
+  }, [navigate]);
 
   return (
     <div className="game">

--- a/packages/client/src/redux/actions/leaderBoardActions.ts
+++ b/packages/client/src/redux/actions/leaderBoardActions.ts
@@ -7,8 +7,11 @@ export const setLeaderBoard = createAsyncThunk(
   async (data: GetLeaders, thunkAPI) => {
     try {
       const res = await getLeaderBoard(data);
-      const leaders = await res.json();
-      return res.ok
+      if ((res as Response)?.status === 401) {
+        return thunkAPI.rejectWithValue('unauthorized');
+      }
+      const leaders = await res?.json();
+      return res?.ok
         ? thunkAPI.fulfillWithValue({ ...leaders })
         : thunkAPI.rejectWithValue('Не удалось получить данные');
     } catch (e) {

--- a/packages/client/src/redux/actions/profileActions.ts
+++ b/packages/client/src/redux/actions/profileActions.ts
@@ -11,8 +11,11 @@ import {
 export const setAvatar = createAsyncThunk('auth/user/avatar', async (data: FormData, thunkAPI) => {
   try {
     const res = await setAvatarRequest(data);
-    const user = await res.json();
-    return res.ok ? thunkAPI.fulfillWithValue({ ...user }) : thunkAPI.rejectWithValue('Не удалось загрузить аватар');
+    if ((res as Response)?.status === 401) {
+      return thunkAPI.rejectWithValue('unauthorized');
+    }
+    const user = await res?.json();
+    return res?.ok ? thunkAPI.fulfillWithValue({ ...user }) : thunkAPI.rejectWithValue('Не удалось загрузить аватар');
   } catch (e) {
     return thunkAPI.rejectWithValue('Не удалось загрузить аватар');
   }
@@ -21,8 +24,11 @@ export const setAvatar = createAsyncThunk('auth/user/avatar', async (data: FormD
 export const setProfileInfo = createAsyncThunk('auth/user', async (data: IChangeInfo, thunkAPI) => {
   try {
     const res = await setProfileInfoRequest(data);
-    const user = await res.json();
-    return res.ok ? thunkAPI.fulfillWithValue({ ...user }) : thunkAPI.rejectWithValue('Не удалось обновить данные');
+    if ((res as Response)?.status === 401) {
+      return thunkAPI.rejectWithValue('unauthorized');
+    }
+    const user = await res?.json();
+    return res?.ok ? thunkAPI.fulfillWithValue({ ...user }) : thunkAPI.rejectWithValue('Не удалось обновить данные');
   } catch (e) {
     return thunkAPI.rejectWithValue('Не удалось обновить данные');
   }
@@ -31,7 +37,10 @@ export const setProfileInfo = createAsyncThunk('auth/user', async (data: IChange
 export const setProfilePassword = createAsyncThunk('auth/user/password', async (data: IChangePassword, thunkAPI) => {
   try {
     const res = await setProfilePasswordRequest(data);
-    return res.ok ? thunkAPI.fulfillWithValue({}) : thunkAPI.rejectWithValue('Не удалось обновить пароль');
+    if ((res as Response)?.status === 401) {
+      return thunkAPI.rejectWithValue('unauthorized');
+    }
+    return res?.ok ? thunkAPI.fulfillWithValue({}) : thunkAPI.rejectWithValue('Не удалось обновить пароль');
   } catch (e) {
     return thunkAPI.rejectWithValue('Не удалось обновить данные');
   }

--- a/packages/client/src/redux/actions/singActions.ts
+++ b/packages/client/src/redux/actions/singActions.ts
@@ -6,13 +6,13 @@ import { getProfileRequest, postLoginRequest, postLogout, postRegisterRequest } 
 export const register = createAsyncThunk('auth/register', async (data: RegisterForm, thunkAPI) => {
   try {
     const res = await postRegisterRequest(data);
-    if (res.ok) {
+    if (res?.ok) {
       const profileRes = await getProfileRequest();
-      if (profileRes.ok) {
+      if (profileRes?.ok) {
         return thunkAPI.fulfillWithValue(await profileRes.json());
       }
     }
-    const err = await res.json();
+    const err = await res?.json();
     throw new Error(err.reason);
   } catch (e) {
     return thunkAPI.rejectWithValue(e);
@@ -22,13 +22,13 @@ export const register = createAsyncThunk('auth/register', async (data: RegisterF
 export const login = createAsyncThunk('auth/login', async (data: LoginForm, thunkAPI) => {
   try {
     const res = await postLoginRequest(data);
-    if (res.ok) {
+    if (res?.ok) {
       const profileRes = await getProfileRequest();
-      if (profileRes.ok) {
+      if (profileRes?.ok) {
         return thunkAPI.fulfillWithValue(await profileRes.json());
       }
     }
-    const err = await res.json();
+    const err = await res?.json();
     throw new Error(err.reason);
   } catch (e) {
     return thunkAPI.rejectWithValue(e);
@@ -38,10 +38,10 @@ export const login = createAsyncThunk('auth/login', async (data: LoginForm, thun
 export const checkLogin = createAsyncThunk('auth/checkLogin', async (data, thunkAPI) => {
   try {
     const res = await getProfileRequest();
-    if (res.ok) {
+    if (res?.ok) {
       return thunkAPI.fulfillWithValue(await res.json());
     }
-    const err = await res.json();
+    const err = await res?.json();
     throw new Error(err.reason);
   } catch (e) {
     return thunkAPI.rejectWithValue(e);
@@ -51,7 +51,7 @@ export const checkLogin = createAsyncThunk('auth/checkLogin', async (data, thunk
 export const logout = createAsyncThunk('auth/logout', async (data, thunkAPI) => {
   try {
     const res = await postLogout();
-    if (res.ok) {
+    if (res?.ok) {
       return thunkAPI.fulfillWithValue(true);
     }
     throw new Error('Не разлогинить пользователя');

--- a/packages/client/src/redux/reducers/userSlice.ts
+++ b/packages/client/src/redux/reducers/userSlice.ts
@@ -27,11 +27,13 @@ export interface UserChars {
 export interface ILeadersSlice {
   leaderList: Record<'data', ILeader>[] | [];
   date: number | undefined;
+  isAuthorized: boolean;
 }
 
 const leadersInitState: ILeadersSlice = {
   leaderList: [],
   date: undefined,
+  isAuthorized: true,
 };
 
 function convertUser(user: UserProps): UserChars {
@@ -115,8 +117,23 @@ export const authSlice = createSlice({
     [setAvatar.fulfilled.type]: (state, action) => {
       state.user.avatar = action.payload.avatar;
     },
+    [setAvatar.rejected.type]: (state, action) => {
+      if (action.payload == 'unauthorized') {
+        state.isAuthorized = false;
+      }
+    },
     [setProfileInfo.fulfilled.type]: (state, action) => {
       state.user = convertUser(action.payload);
+    },
+    [setProfileInfo.rejected.type]: (state, action) => {
+      if (action.payload == 'unauthorized') {
+        state.isAuthorized = false;
+      }
+    },
+    [setLeaderBoard.rejected.type]: (state, action) => {
+      if (action.payload == 'unauthorized') {
+        state.isAuthorized = false;
+      }
     },
   },
 });
@@ -129,6 +146,7 @@ export const leadersSlice = createSlice({
     [setLeaderBoard.fulfilled.type]: (state, action) => {
       state.leaderList = action.payload;
       state.date = Date.now();
+      state.isAuthorized = true;
     },
   },
 });

--- a/packages/client/src/utils/api.ts
+++ b/packages/client/src/utils/api.ts
@@ -48,6 +48,8 @@ export const postLogout = async () =>
     method: 'POST',
     headers: headers.get,
     credentials: 'include',
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const postRegisterRequest = async (data: RegisterForm) =>
@@ -56,6 +58,8 @@ export const postRegisterRequest = async (data: RegisterForm) =>
     headers: headers.post,
     body: JSON.stringify(data),
     credentials: 'include',
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const postLoginRequest = async (data: LoginForm) =>
@@ -64,6 +68,8 @@ export const postLoginRequest = async (data: LoginForm) =>
     headers: headers.post,
     body: JSON.stringify(data),
     credentials: 'include',
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const getProfileRequest = async () =>
@@ -71,6 +77,8 @@ export const getProfileRequest = async () =>
     method: 'GET',
     headers: { ...headers.get },
     credentials: 'include',
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const setAvatarRequest = async (data: FormData) =>
@@ -79,6 +87,8 @@ export const setAvatarRequest = async (data: FormData) =>
     headers: { accept: 'application/xml' },
     credentials: 'include',
     body: data,
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const setProfileInfoRequest = async (data: IChangeInfo) =>
@@ -87,6 +97,8 @@ export const setProfileInfoRequest = async (data: IChangeInfo) =>
     headers: headers.put,
     credentials: 'include',
     body: JSON.stringify(data),
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const setProfilePasswordRequest = async (data: IChangePassword) =>
@@ -95,6 +107,8 @@ export const setProfilePasswordRequest = async (data: IChangePassword) =>
     headers: headers.put,
     credentials: 'include',
     body: JSON.stringify({ ...data }),
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const addToLeaderBoard = async (data: AddLeader) =>
@@ -103,6 +117,8 @@ export const addToLeaderBoard = async (data: AddLeader) =>
     headers: headers.post,
     credentials: 'include',
     body: JSON.stringify({ ...data }),
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });
 
 export const getLeaderBoard = async (data: GetLeaders) =>
@@ -111,4 +127,6 @@ export const getLeaderBoard = async (data: GetLeaders) =>
     headers: headers.post,
     credentials: 'include',
     body: JSON.stringify({ ...data }),
+  }).catch((error) => {
+    alert(`Ошибка: ${(error as Error)?.message}`);
   });


### PR DESCRIPTION
### Какую задачу решаем

> При открытии страницы / в консоли браузера летит неперехваченное исключение из-за 401, "нет авторизации.
> Все промисы должны иметь catch-блок.

Catch я понапихала в api с выводом алерта, отдельно привесила на все action'ы, кроме авторизации, регистрации и выхода (они и так обрабатываются) на reject с 401 сброс авторизации. Не очень уверена, что так делать правильно, но вроде бы работает.


### Скриншоты/видяшка (если есть)

### TBD (если есть)